### PR TITLE
Prohibit Solar Panels inside Factories via collision layers

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,0 +1,12 @@
+local solar_panels = data.raw["solar-panel"]
+
+for _, v in pairs(solar_panels) do
+  local collision_mask = v.collision_mask
+  if collision_mask == nil then
+    -- If collision_mask is nil it defaults to "item-layer", "object-layer", "player-layer" and "water-tile" so we have to add those layers and our new layer
+    collision_mask = {"item-layer", "object-layer", "player-layer", "water-tile", solar_panel_collision_layer}
+  else
+    collision_mask[#collision_mask] = solar_panel_collision_layer
+  end
+  v.collision_mask = collision_mask
+end

--- a/data.lua
+++ b/data.lua
@@ -1,3 +1,6 @@
+-- Make the collision layer that blocks solar panels inside factories global
+local collision_mask_util = require "__core__/lualib/collision-mask-util"
+solar_panel_collision_layer = collision_mask_util.get_first_unused_layer()
 
 require("prototypes.factory")
 require("prototypes.component")

--- a/locale/en/factorissimo2.cfg
+++ b/locale/en/factorissimo2.cfg
@@ -76,6 +76,15 @@ factory-wall-1=Factory wall
 factory-wall-2=Factory wall
 factory-wall-3=Factory wall
 out-of-factory=Factory wall
+factory-floor-1=Factory Floor
+factory-entrance-1=Factory Floor
+factory-pattern-1=Factory Floor
+factory-floor-2=Factory Floor
+factory-entrance-2=Factory Floor
+factory-pattern-2=Factory Floor
+factory-floor-3=Factory Floor
+factory-entrance-3=Factory Floor
+factory-pattern-3=Factory Floor
 
 [factory-connection-text]
 input-mode=Input mode

--- a/prototypes/tile.lua
+++ b/prototypes/tile.lua
@@ -1,5 +1,6 @@
 local F = "__Factorissimo2__"
 
+
 alien_biomes_priority_tiles = alien_biomes_priority_tiles or {}
 
 local function make_tile(tinfo)
@@ -71,7 +72,8 @@ end
 
 local function floor_mask()
 	return {
-		"ground-tile"
+		"ground-tile",
+		solar_panel_collision_layer
 	}
 end
 


### PR DESCRIPTION
Adds a collision layer to factory tiles and all solar panels. Major advantage is that solar panels on the cursor are displayed with a red tint inside factories, so that it is clear from the start that they do not work inside.

Tested it in Vanilla and Space Exploration but it should cover all solar panels in all mods.

I am not exactly sure what [line 866](https://github.com/notnotmelon/Factorissimo2/blob/ea8bd9dbf1d5ac6b98759c351813f6a5e4c73d06/control.lua#L866) in ``control.lua`` covers but I left it in and only commented out the part where you cancel construction of solar panels via events. 